### PR TITLE
keyboad doesn't block and each page has a configurable duration

### DIFF
--- a/ThreadSignaller.py
+++ b/ThreadSignaller.py
@@ -1,12 +1,22 @@
 import Queue
 
 
-class CleanExit:
+class CleanExit(object):
     pass
 
 
-class InterruptWait:
+class InterruptStandardLoop(object):
     pass
+
+
+class ShowPage(object):
+    def __init__(self, page_num):
+        self.page_num = page_num
+
+
+class ShowGreetingPage(object):
+    def __init__(self, barcode):
+        self.barcode = barcode
 
 
 queue = Queue.Queue()

--- a/ceefax.py
+++ b/ceefax.py
@@ -1,6 +1,7 @@
 # width:79
 # height: 30
 
+import config
 import sys
 from os import listdir
 from os.path import isfile
@@ -61,43 +62,77 @@ def restart_computer():
 
 def stop_execution():
     ThreadSignaller.queue.put(ThreadSignaller.CleanExit)
-    sys.exit()
 
 
-def sleep(secs):
-    sleeping_time_ms = 100
-    num_of_cycles = int(round(secs * 1000 / sleeping_time_ms))
+def get_greeting_page(barcode):
+    namefile_path = "/home/pi/cards/" + barcode
+    extra = ""
+    if isfile(namefile_path):
+        (name, house) = points.get_name_house(namefile_path)
 
-    for i in range(num_of_cycles):
-        try:
-            signal = ThreadSignaller.queue.get_nowait()
-            if signal == ThreadSignaller.CleanExit:
-                sys.exit()
-            elif signal == ThreadSignaller.InterruptWait:
-                return
-        except Queue.Empty:
-            pass
+        if not house:
+            extra = """Error finding your house. Please
+                        report to Scroggs."""
 
-        time.sleep(sleeping_time_ms / 1000.0)
+        time = now.now().strftime("%H")
+
+        name_file = points.read_name_file(namefile_path)
+        if points.should_add_morning_points(time, house, name_file,
+                                            barcode):
+            points_added = points.add_morning_points(time, house, barcode)
+            extra = str(points_added) + " points to " + house + "!"
+
+        name_page = page.NamePage(name, extra=extra)
+    else:
+        name_page = page.NamePage(barcode, large=False)
+    return name_page
 
 
 def pull_new_version():
-            from os import system
-            print("Pulling newest version.")
-            try:
-                system("cd /home/pi/ceefax;git pull")
-            except:
-                pass
+    from os import system
+    print("Pulling newest version.")
+    try:
+        system("cd /home/pi/ceefax;git pull")
+    except:
+        pass
 
 
 class LoopManager(object):
     def __init__(self):
         pass
 
+    def _get_cycles_left(self, duration_sec):
+        return int(round(duration_sec * 1000.0 / config.sleeping_time_ms))
+
     def standard(self):
-        pageFactory.show_random()
-        REFRESH_RATE_SECS = 30
-        sleep(REFRESH_RATE_SECS)
+        i = 0
+        num_cycles_left = 0
+        page = None
+
+        while True:
+            if i >= num_cycles_left:
+                page = pageFactory.get_loaded_random()
+            try:
+                signal = ThreadSignaller.queue.get_nowait()
+                if isinstance(signal, ThreadSignaller.ShowPage):
+                    page = pageFactory.get_reloaded_page(signal.page_num)
+                elif isinstance(signal, ThreadSignaller.ShowGreetingPage):
+                    page = get_greeting_page(signal.barcode)
+                elif signal == ThreadSignaller.CleanExit:
+                    sys.exit()
+                elif signal == ThreadSignaller.InterruptStandardLoop:
+                    break
+            except Queue.Empty:
+                pass
+
+            if page:
+                num_cycles_left = self._get_cycles_left(page.duration_sec)
+                i = 0
+                page.show()
+                page = None
+            if not page:
+                i += 1
+                time.sleep(config.sleeping_time_ms / 1000.0)
 
     def current(self):
         self.standard()
@@ -106,10 +141,11 @@ loop_manager = LoopManager()
 
 
 def name_page_handler(input):
+    # make sure the Keyboard thread is never blocked by loading pages
     if len(input) <= 3:
         while len(input) < 3:
             input = "0" + input
-        pageFactory.get_reloaded_page(input).show()
+        ThreadSignaller.queue.put(ThreadSignaller.ShowPage(input))
     elif input == "....":
         stop_execution()
     elif input == "00488a0488":
@@ -117,25 +153,4 @@ def name_page_handler(input):
     elif input == "0026360488":
         pull_new_version()
     else:
-        barcode = input
-        namefile_path = "/home/pi/cards/" + barcode
-        extra = ""
-        if isfile(namefile_path):
-            (name, house) = points.get_name_house(namefile_path)
-            
-            if not house:
-                extra = """Error finding your house. Please
-                            report to Scroggs."""
-
-            time = now.now().strftime("%H")
-
-            name_file = points.read_name_file(namefile_path)
-            if points.should_add_morning_points(time, house, name_file,
-                                                barcode):
-                points_added = points.add_morning_points(time, house, barcode)
-                extra = str(points_added) + " points to " + house + "!"
-
-            name_page = page.NamePage(name, extra=extra)
-        else:
-            name_page = page.NamePage(input, large=False)
-        name_page.show()
+        ThreadSignaller.queue.put(ThreadSignaller.ShowGreetingPage(input))

--- a/config.py
+++ b/config.py
@@ -14,3 +14,6 @@ current_dir = os.path.dirname(os.path.abspath(
 
 dummy_data_folder = "dummy_data"
 birthday_file = get_bd_filepath()
+
+sleeping_time_ms = 100
+default_page_duration_sec = int(os.getenv('default_page_duration_sec', 30))

--- a/page/NamePage.py
+++ b/page/NamePage.py
@@ -2,18 +2,20 @@ from random import random,randint,choice
 from page import Page
 from printer import instance as printer
 import colours
-from points import add_points 
+from points import add_points
 
 def colour_print(text):
     return colours.colour_print(text, colours.Background.RED, colours.Foreground.BLACK)
 
+
 class NamePage(Page):
-    def __init__(self, name,large=True,extra=""):
+    def __init__(self, name, large=True,extra=""):
         super(NamePage, self).__init__("???")
         self.name = name
         self.title = "Greeting"
         self.large = large
         self.extra = extra
+        self.duration_sec = 5
         self.reload()
 
     def generate_content(self):
@@ -26,7 +28,6 @@ class NamePage(Page):
                      u"\u4f60\u597d", "Booyakasha"]
 
         greeting = choice(greetings)
-        #greeting = greetings[-1]
         if "Rafael" in name:
             if random()<0.6:
                 greeting = "Muy Feo"

--- a/page/Page.py
+++ b/page/Page.py
@@ -2,6 +2,7 @@ from math import floor
 import logging
 import screen
 import now
+import config
 
 
 def random_error(string):
@@ -27,6 +28,7 @@ class Page(object):
         self.number = str(number)
         self.loaded = False
         self.title = ""
+        self.duration_sec = config.default_page_duration_sec
 
     def loop(self):
         pass
@@ -77,6 +79,7 @@ class FailPage(Page):
         super(FailPage, self).__init__("---")
         self.content = "Page failed to load...\n\n2 points to Slytherin!"
         self.is_enabled = False
+        self.duration_sec = 2
 
     def generate_content(self):
         from points import add_points

--- a/page/PageFactory.py
+++ b/page/PageFactory.py
@@ -1,21 +1,23 @@
 import random
 from page import Page
-from time import strftime
+
 
 def get_page_factory():
-    if not isinstance(PageFactory._instance,PageFactory):
+    if not isinstance(PageFactory._instance, PageFactory):
         PageFactory._instance = PageFactory()
     return PageFactory._instance
 
 
 class PageFactory:
     _instance = None
+
     def __init__(self):
         from page import FailPage
         self.i = 0
         self.pages = {}
         self.fail_page = FailPage()
         self.fake_page = Page("---")
+        self.fake_page.duration_sec = self.fail_page.duration_sec
         self.fake_page.content = "This page does not exist.\nTry the index on page 100."
         self.fake_page.loaded = False
         self.fake_page.is_enabled = False
@@ -23,24 +25,23 @@ class PageFactory:
     def add(self, page):
         self.pages[page.number] = page
 
-    def show_random(self):
+    def get_loaded_random(self):
         page = self.fail_page
         while not page.loaded:
             page = random.choice(self.get_enabled_pages(str(self.i)))
             self.i += 1
             self.i %= 10
             page.reload()
-        page.show()
+        return page
 
     def print_all(self):
         items = self.pages.items()
         items.sort()
-        for page_num,page in items:
+        for page_num, page in items:
             p = ""
             if not page.is_enabled: p += page.colours.Foreground.RED
             p += (page_num+" ")
             p += (page.title)
-            #p += (" "*(45-len(page.title)))
             if not page.is_enabled: p += page.colours.Foreground.DEFAULT
             print(p)
 
@@ -54,11 +55,11 @@ class PageFactory:
             return self.fail_page
         return self.pages[number]
 
-    def get_enabled_pages(self,starting="0"):
+    def get_enabled_pages(self, starting="0"):
         if starting == "0":
             return [self.pages["200"]]
         output = [page for page in self.pages.values() if page.is_enabled and page.number[0]==starting]
-        if len(output)>0:
+        if len(output) > 0:
             return output
         else:
             return [page for page in self.pages.values() if page.is_enabled]

--- a/page/PrisonersPage.py
+++ b/page/PrisonersPage.py
@@ -14,12 +14,12 @@ class PrisonersPage(Page):
 
     def keyboard_handler(self, input):
         if input == "000":
-            ThreadSignaller.queue.put(ThreadSignaller.InterruptWait)
             Keyboard.restore_subscribers()
             ceefax.loop_manager.current = ceefax.loop_manager.standard
 
     def reload(self):
         Page.reload(self)
+        ThreadSignaller.queue.put(ThreadSignaller.InterruptStandardLoop)
         Keyboard.save_subscribers()
         Keyboard.clear_subscribers()
         Keyboard.subscribe(self.keyboard_handler)
@@ -30,4 +30,4 @@ class PrisonersPage(Page):
         self.content = "A game will appear here shortly..."
 
     def loop(self):
-        ceefax.sleep(10)
+        pass


### PR DESCRIPTION
It occurred to me that my name_page_handler was responsible for calling page_factory and waiting until a page loads - but that's a bad practice as the keyboard thread shouldn't do any processing. Whilst I was fixing it I rewrote the main loop slightly - and now each page has capability for duration: Page.duration_sec is set to 30, NamePage to 5, Fail and Fake pages to 3 :). I suggest you adjust durations of empty pages such as subtitles and chalkdust as you see fit to make use of this feature.
